### PR TITLE
Make sure that cookies are included in the manifest request in order …

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import mockManifest from '../json/lunchroom-manners';
 
 export function fetchManifest(url) {
-  return fetch(url)
+  return fetch(url, {credentials: 'include'})
     .then(response => {
       if (response.ok) {
         return response.json();


### PR DESCRIPTION
…to retrieve manifests behind authentication (not iiif-authentication) as well as CORS

Resolves https://github.com/samvera-labs/avalon-bundle/issues/162.

I tested this locally by modifying the JS under `node-modules`.  I had a lot of trouble trying to use yarn with my local checkout.  I think this PR solves the issue but I'm not 100% certain since there are still a number of other issues around the player right now.  The player did request the manifest and it succeeded instead of returning a 302 to the sign in page.